### PR TITLE
Increase concurrent download limit and correct path parameters

### DIFF
--- a/src/Gml.Client/GmlClientManager.cs
+++ b/src/Gml.Client/GmlClientManager.cs
@@ -131,7 +131,7 @@ public class GmlClientManager : IGmlClientManager
         await _systemProcedures.RemoveFiles(profileInfo);
 
         var updateFiles = _systemProcedures.FindErroneousFiles(profileInfo, _installationDirectory);
-        await _apiProcedures.DownloadFiles(_installationDirectory, updateFiles.ToArray(), 16, cancellationToken);
+        await _apiProcedures.DownloadFiles(_installationDirectory, updateFiles.ToArray(), 60, cancellationToken);
     }
 
     public async Task<(IUser User, string Message, IEnumerable<string> Details)> Auth(string login, string password,

--- a/src/Gml.Client/Helpers/ApiProcedures.cs
+++ b/src/Gml.Client/Helpers/ApiProcedures.cs
@@ -103,7 +103,7 @@ public class ApiProcedures
 
         var parameters = new Dictionary<string, string>
         {
-            { "{localPath}", profilePath },
+            { "{localPath}", installationDirectory },
             { "{authEndpoint}", $"{_httpClient.BaseAddress.AbsoluteUri}api/v1/integrations/authlib/minecraft" },
         };
 
@@ -116,7 +116,7 @@ public class ApiProcedures
 
         process.StartInfo = new ProcessStartInfo
         {
-            FileName = profileDto.JavaPath.Replace("{localPath}", profilePath),
+            FileName = profileDto.JavaPath.Replace("{localPath}", installationDirectory),
             Arguments = profileDto.Arguments,
             WorkingDirectory = profilePath
         };


### PR DESCRIPTION
The concurrent download limit in the DownloadFiles method was increased from 16 to 60 for efficiency. Also, the incorrect 'profilePath' parameter was replaced with 'installationDirectory' in ApiProcedures class, to ensure correct paths are used in the process start info and parameters dictionary.